### PR TITLE
fix(tracktools): tags parsing

### DIFF
--- a/cmd/tracktools/cmd/.tracktools.toml
+++ b/cmd/tracktools/cmd/.tracktools.toml
@@ -34,6 +34,6 @@ Encoder = "laptimer"
 Compress = false
 Track = ""
 Vehicle = ""
-Tags = []
+Tags = ["Me"]
 Note = ""
 StartDate = ""

--- a/cmd/tracktools/cmd/convert.go
+++ b/cmd/tracktools/cmd/convert.go
@@ -32,6 +32,10 @@ type convertCmd struct {
 }
 
 func (c *convertCmd) RunE(cmd *cobra.Command, args []string) (err error) { // nolint: nonamedreturns
+	if err := loadConfig(cmd, c); err != nil {
+		return err
+	}
+
 	// Validate encoder / decoder.
 	switch c.Decoder {
 	case trackAddict:

--- a/cmd/tracktools/cmd/gopro_convert.go
+++ b/cmd/tracktools/cmd/gopro_convert.go
@@ -14,7 +14,7 @@ type goproConvertCmd struct {
 }
 
 func (c *goproConvertCmd) RunE(cmd *cobra.Command, args []string) error {
-	if err := loadConfig("gopro.convert", &c.cfg, cmd.Flags()); err != nil {
+	if err := loadConfig(cmd, c); err != nil {
 		return err
 	}
 

--- a/cmd/tracktools/cmd/root.go
+++ b/cmd/tracktools/cmd/root.go
@@ -10,7 +10,6 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 )
 
@@ -81,7 +80,7 @@ func (r *rootCommand) PersistentPreRunE(cmd *cobra.Command, args []string) error
 		return err
 	}
 
-	return r.bindFlags(v, cmd)
+	return nil
 }
 
 // configSpec sets our config spec on v.
@@ -147,27 +146,6 @@ func (r *rootCommand) loadConfig(v *viper.Viper) error {
 	log.Print("Using config file: ", v.ConfigFileUsed())
 
 	return nil
-}
-
-// bindFlags binds each cobra flag to its associated viper config
-// from our config file.
-func (r *rootCommand) bindFlags(v *viper.Viper, cmd *cobra.Command) error {
-	var err error
-	cmd.Flags().VisitAll(func(f *pflag.Flag) {
-		if f.Changed || err != nil {
-			// Flag has been set don't set from config.
-			return
-		}
-
-		if name := configName(f); v.IsSet(name) {
-			val := v.GetString(name)
-			if err = f.Value.Set(val); err != nil {
-				err = fmt.Errorf("set flag %q to %q: %w", name, val, err)
-			}
-		}
-	})
-
-	return err
 }
 
 // RootCmd returns the root command for doc generation.

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/stevenh/tracktools
 go 1.18
 
 require (
-	github.com/iancoleman/strcase v0.2.0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/rs/zerolog v1.27.0

--- a/go.sum
+++ b/go.sum
@@ -124,8 +124,6 @@ github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
-github.com/iancoleman/strcase v0.2.0 h1:05I4QRnGpI0m37iZQRuskXh+w77mr6Z41lwQzuHLwW0=
-github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=

--- a/pkg/laptimer/types.go
+++ b/pkg/laptimer/types.go
@@ -46,9 +46,9 @@ type Lap struct {
 	AmbientTemp      Float1dp  `xml:"ambientTemp,omitempty"`
 	AmbientPressure  Float0dp  `xml:"ambientPressure,omitempty"`  // TODO(steve): Is this in hPa?
 	RelativeHumidity Float2dp  `xml:"relativeHumidity,omitempty"` // TODO(steve): Percentage?
-	Videos           []Video   `xml:"video"`
+	Videos           []Video   `xml:"video,omitempty"`
 	Note             string    `xml:"note,omitempty"`
-	Tags             Tags      `xml:"tags"`
+	Tags             Tags      `xml:"tags,omitempty"`
 	Recording        Recording `xml:"recording"`
 }
 


### PR DESCRIPTION
Refactor tracktools flag and config parsing to fix serialisation issues for slice flags.

This removes `bindFlags` in favour of using `loadConfig` which has the additional context needed to avoid using viper serialisation.

Also:
* Set default convert.Tags to ["Me"].