### PR TITLE
feat(tracktools): add gopro laptimes cmd

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -58,6 +58,7 @@ linters:
     - tagliatelle
     - gomoddirectives
     - ifshort
+    - ireturn
 
 issues:
   exclude-use-default: false

--- a/cmd/tracktools/cmd/.tracktools.toml
+++ b/cmd/tracktools/cmd/.tracktools.toml
@@ -28,6 +28,10 @@ LogLevel = "warn"
 Overwrite = false # Overwrite existing files.
 SkipNames = [] # Filenames to skip
 
+[gopro.laptimes]
+Tolerance = 1
+Start = {Latitude = 0, Longitude = 0, Bearing = 0, Distance = 10}
+
 [convert]
 Decoder = "trackaddict"
 Encoder = "laptimer"

--- a/cmd/tracktools/cmd/gopro_laptimes.go
+++ b/cmd/tracktools/cmd/gopro_laptimes.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stevenh/tracktools/pkg/gopro/gpmf/geo"
 )
 
-// goproLapTimesCmd represents the convert command.
+// goproLapTimesCmd represents the gopro laptimes command.
 type goproLapTimesCmd struct {
 	Start     Start
 	Tolerance float64

--- a/cmd/tracktools/cmd/gopro_laptimes.go
+++ b/cmd/tracktools/cmd/gopro_laptimes.go
@@ -1,0 +1,92 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/stevenh/tracktools/pkg/gopro/gpmf"
+	"github.com/stevenh/tracktools/pkg/gopro/gpmf/geo"
+)
+
+// goproLapTimesCmd represents the convert command.
+type goproLapTimesCmd struct {
+	Start     Start
+	Tolerance float64
+
+	p *geo.Processor
+}
+
+func (c *goproLapTimesCmd) RunE(cmd *cobra.Command, args []string) error {
+	if err := loadConfig(cmd, c); err != nil {
+		return err
+	}
+
+	c.Start.calculate()
+	c.p = geo.NewProcessor(geo.Tolerance(c.Tolerance))
+
+	dec := &gpmf.Decoder{}
+	for _, fn := range args {
+		if err := c.process(dec, fn); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (c *goproLapTimesCmd) process(dec *gpmf.Decoder, file string) error {
+	f, err := os.Open(file)
+	if err != nil {
+		return err
+	}
+
+	defer f.Close() // nolint: errcheck
+
+	data, err := dec.Decode(f)
+	if err != nil {
+		return err
+	}
+
+	return gpmf.Walk(data, c.walk)
+}
+
+func (c *goproLapTimesCmd) walk(e *gpmf.Element) error {
+	data, ok := e.Data.([]gpmf.GPS)
+	if !ok {
+		return nil
+	}
+
+	for _, v := range data {
+		if c.p.OnLine(v.Latitude, v.Longitude, c.Start.lat1, c.Start.lon1, c.Start.lat2, c.Start.lon2) {
+			fmt.Println("start:", v)
+		}
+	}
+
+	return nil
+}
+
+func addGoproLapTimes() {
+	c := goproLapTimesCmd{}
+	cmd := &cobra.Command{
+		Use:   "laptimes [file1] ... [fileN]",
+		Short: "LapTimes reports laptimes of GoPro videos",
+		Long:  `LapTimes reports laptimes of GoPro based on the GPS metadata information.`,
+		Args:  cobra.MinimumNArgs(1),
+		RunE:  c.RunE,
+	}
+
+	fs := cmd.Flags()
+	fs.Float64Var(&c.Start.Latitude, "latitude", 0, "override start latitude")
+	fs.Float64Var(&c.Start.Longitude, "longitude", 0, "override start longitude")
+	fs.Float64Var(&c.Start.Bearing, "bearing", 0, "override start bearing")
+	fs.Float64Var(&c.Start.Distance, "distance", 0, "override start distance")
+	fs.Float64Var(&c.Tolerance, "tolerance", 0, "override tolerance")
+	annotate(fs, "gopro.laptimes")
+
+	goproCmd.AddCommand(cmd)
+}
+
+func init() { // nolint: gochecknoinits
+	addGoproLapTimes()
+}

--- a/cmd/tracktools/cmd/types.go
+++ b/cmd/tracktools/cmd/types.go
@@ -3,10 +3,18 @@ package cmd
 import (
 	"fmt"
 	"time"
+
+	"github.com/tidwall/geodesic"
 )
 
 const (
+	// dateFormat is the format used for date output.
 	dateFormat = "2006-01-02"
+)
+
+var (
+	// gd is the geodesic used for calculations.
+	gd = geodesic.WGS84
 )
 
 type date time.Time
@@ -47,4 +55,21 @@ func (d *date) Set(val string) error {
 // Type implements pflags.Value.
 func (d date) Type() string {
 	return "date"
+}
+
+// Start represents a track start point.
+type Start struct {
+	Latitude  float64
+	Longitude float64
+	Bearing   float64
+	Distance  float64
+
+	lat1, lon1 float64
+	lat2, lon2 float64
+}
+
+// calculates the start and end latitudes and longitudes of the start line.
+func (s *Start) calculate() {
+	gd.Direct(s.Latitude, s.Longitude, s.Bearing+90, s.Distance, &s.lat1, &s.lon1, nil)
+	gd.Direct(s.Latitude, s.Longitude, s.Bearing-90, s.Distance, &s.lat2, &s.lon2, nil)
 }

--- a/cmd/tracktools/docs/tracktools_gopro.md
+++ b/cmd/tracktools/docs/tracktools_gopro.md
@@ -23,4 +23,5 @@ Provides a set of commands for manipulating GoPro videos.
 
 * [tracktools](tracktools.md)	 - A set of tools for creating track videos
 * [tracktools gopro convert](tracktools_gopro_convert.md)	 - Converts GoPro videos
+* [tracktools gopro laptimes](tracktools_gopro_laptimes.md)	 - LapTimes reports laptimes of GoPro videos
 

--- a/cmd/tracktools/docs/tracktools_gopro_laptimes.md
+++ b/cmd/tracktools/docs/tracktools_gopro_laptimes.md
@@ -1,0 +1,34 @@
+## tracktools gopro laptimes
+
+LapTimes reports laptimes of GoPro videos
+
+### Synopsis
+
+LapTimes reports laptimes of GoPro based on the GPS metadata information.
+
+```
+tracktools gopro laptimes [file1] ... [fileN] [flags]
+```
+
+### Options
+
+```
+      --bearing float     override start bearing
+      --distance float    override start distance
+  -h, --help              help for laptimes
+      --latitude float    override start latitude
+      --longitude float   override start longitude
+      --tolerance float   override tolerance
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string   config file (Default .tracktools.toml)
+  -v, --verbose count   verbose output
+```
+
+### SEE ALSO
+
+* [tracktools gopro](tracktools_gopro.md)	 - Provides commands for manipulating GoPro videos
+

--- a/pkg/gopro/gpmf/fixed.go
+++ b/pkg/gopro/gpmf/fixed.go
@@ -61,7 +61,7 @@ func (x Int16_16) mul(y Int16_16) Int16_16 {
 
 // muli multiplies two integer values, returning the signed integer
 // result as two signed values.
-func muli[I ~int32 | ~int64, O uint32 | uint64](s int, u, v I) (lo, hi O) { // nolint: ireturn
+func muli[I ~int32 | ~int64, O uint32 | uint64](s int, u, v I) (lo, hi O) {
 	var mask I = 1<<s - 1
 
 	u1 := O(u >> s)


### PR DESCRIPTION
Add a gopro laptimes command that parses a GoPro mp4 and outputs the time at which it detects the GPS data crosses the start / finish line.