### PR TITLE
feat(tracktool): add gopro render cmd

### DIFF
--- a/cmd/tracktools/cmd/.tracktools.toml
+++ b/cmd/tracktools/cmd/.tracktools.toml
@@ -32,6 +32,13 @@ SkipNames = [] # Filenames to skip
 Tolerance = 1
 Start = {Latitude = 0, Longitude = 0, Bearing = 0, Distance = 10}
 
+[gopro.render]
+Width = 4096
+Height = 2160
+MinDoP = 10
+MinGood = 5
+Start = {Latitude = 0, Longitude = 0, Bearing = 0, Distance = 10}
+
 [convert]
 Decoder = "trackaddict"
 Encoder = "laptimer"

--- a/cmd/tracktools/cmd/gopro_render.go
+++ b/cmd/tracktools/cmd/gopro_render.go
@@ -1,0 +1,136 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/golang/geo/s2"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+	"github.com/stevenh/tracktools/pkg/gopro/gpmf"
+	"github.com/stevenh/tracktools/pkg/image"
+)
+
+// goproRenderCmd represents the gopro render command.
+type goproRenderCmd struct {
+	MinDoP        float64
+	MinGood       int
+	Width, Height int
+	Start         Start
+
+	data []s2.LatLng
+	good int
+}
+
+func (c *goproRenderCmd) RunE(cmd *cobra.Command, args []string) error {
+	if err := loadConfig(cmd, c); err != nil {
+		return err
+	}
+
+	c.Start.calculate()
+
+	dec := &gpmf.Decoder{}
+	f, err := os.Open(args[0])
+	if err != nil {
+		return fmt.Errorf("render: open %w", err)
+	}
+
+	defer f.Close() // nolint: errcheck
+
+	data, err := dec.Decode(f)
+	if err != nil {
+		return fmt.Errorf("render: decode %q: %w", args[0], err)
+	}
+
+	if err := gpmf.Walk(data, c.walk); err != nil {
+		return fmt.Errorf("render: walk %q: %w", args[0], err)
+	} else if len(c.data) == 0 {
+		return fmt.Errorf("render: walk %q: no gps data found", args[0])
+	}
+
+	r := image.New(c.Width, c.Height)
+	r.Provider("tracktools")
+	r.Start(c.Start.lat1, c.Start.lon1, c.Start.lat2, c.Start.lon2)
+	r.AddPath(c.data, image.Red)
+
+	if err := r.Render(args[1]); err != nil {
+		return fmt.Errorf("render: image %q: %w", args[1], err)
+	}
+
+	log.Info().Str("file", args[1]).Msg("image rendered")
+
+	return nil
+}
+
+// walk is a gpmf.WalkFunc which looks for GPS data, validates
+// it and stores if it passes.
+// Validation is based off the GPS Dilution of Precision value
+// with only values above MinDoP being used.
+// MinGood is also used to filter out bad data close to the
+// start of the dataset.
+func (c *goproRenderCmd) walk(e *gpmf.Element) error {
+	data, ok := e.Data.(gpmf.GPSData)
+	if !ok {
+		return nil
+	}
+
+	for _, v := range data {
+		var dop gpmf.GPSDoP = 100 // Default to bad data.
+		if v, ok := e.MetadataByKey(gpmf.KeyGSPDoP); ok {
+			if f, ok := v.(gpmf.GPSDoP); ok {
+				dop = f
+			}
+		}
+
+		if float64(dop) > c.MinDoP {
+			// Bad data.
+			c.good--
+
+			switch {
+			case c.good < 0:
+				// Prevent it going negative.
+				c.good = 0
+				fallthrough
+			case c.good < c.MinGood:
+				// We have less than MinGood delete all previous
+				// data to avoid a poor quality path in the render.
+				c.data = c.data[:0]
+				continue
+			}
+		} else {
+			c.good++
+		}
+
+		c.data = append(c.data,
+			s2.LatLngFromDegrees(v.Latitude, v.Longitude),
+		)
+	}
+
+	return nil
+}
+
+func addGoproRender() {
+	c := goproRenderCmd{data: make([]s2.LatLng, 0, 100)}
+	cmd := &cobra.Command{
+		Use:   "render [input mp4] [output image]",
+		Short: "Renders image of GoPro GPS data",
+		Long:  `Renders a image of GoPro GPS data.`,
+		Args:  cobra.ExactArgs(2),
+		RunE:  c.RunE,
+	}
+
+	fs := cmd.Flags()
+	fs.IntVar(&c.MinGood, "min-good", 0, "override minimum good measurements")
+	fs.Float64Var(&c.MinDoP, "min-dop", 0, "override GPS Dilution of Precision filter")
+	fs.Float64Var(&c.Start.Latitude, "latitude", 0, "override start latitude")
+	fs.Float64Var(&c.Start.Longitude, "longitude", 0, "override start longitude")
+	fs.Float64Var(&c.Start.Bearing, "bearing", 0, "override start bearing")
+	fs.Float64Var(&c.Start.Distance, "distance", 0, "override start distance")
+	annotate(fs, "gopro.render")
+
+	goproCmd.AddCommand(cmd)
+}
+
+func init() { // nolint: gochecknoinits
+	addGoproRender()
+}

--- a/cmd/tracktools/cmd/gopro_render.go
+++ b/cmd/tracktools/cmd/gopro_render.go
@@ -62,12 +62,11 @@ func (c *goproRenderCmd) RunE(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// walk is a gpmf.WalkFunc which looks for GPS data, validates
-// it and stores if it passes.
-// Validation is based off the GPS Dilution of Precision value
-// with only values above MinDoP being used.
-// MinGood is also used to filter out bad data close to the
-// start of the dataset.
+// walk is a gpmf.WalkFunc which looks for GPS data, validates and
+// stores for rendering if it passes.
+// Validation is based off the GPS Dilution of Precision with only values
+// above MinDoP being used. MinGood is also used to filter out bad data
+// close to the start of the dataset.
 func (c *goproRenderCmd) walk(e *gpmf.Element) error {
 	data, ok := e.Data.(gpmf.GPSData)
 	if !ok {

--- a/cmd/tracktools/docs/tracktools_gopro.md
+++ b/cmd/tracktools/docs/tracktools_gopro.md
@@ -24,4 +24,5 @@ Provides a set of commands for manipulating GoPro videos.
 * [tracktools](tracktools.md)	 - A set of tools for creating track videos
 * [tracktools gopro convert](tracktools_gopro_convert.md)	 - Converts GoPro videos
 * [tracktools gopro laptimes](tracktools_gopro_laptimes.md)	 - LapTimes reports laptimes of GoPro videos
+* [tracktools gopro render](tracktools_gopro_render.md)	 - Renders image of GoPro GPS data
 

--- a/cmd/tracktools/docs/tracktools_gopro_render.md
+++ b/cmd/tracktools/docs/tracktools_gopro_render.md
@@ -1,0 +1,35 @@
+## tracktools gopro render
+
+Renders image of GoPro GPS data
+
+### Synopsis
+
+Renders a image of GoPro GPS data.
+
+```
+tracktools gopro render [input mp4] [output image] [flags]
+```
+
+### Options
+
+```
+      --bearing float     override start bearing
+      --distance float    override start distance
+  -h, --help              help for render
+      --latitude float    override start latitude
+      --longitude float   override start longitude
+      --min-dop float     override GPS Dilution of Precision filter
+      --min-good int      override minimum good measurements
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string   config file (Default .tracktools.toml)
+  -v, --verbose count   verbose output
+```
+
+### SEE ALSO
+
+* [tracktools gopro](tracktools_gopro.md)	 - Provides commands for manipulating GoPro videos
+

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,12 @@ require (
 require (
 	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/flopp/go-coordsparser v0.0.0-20201115094714-8baaeb7062d5 // indirect
+	github.com/flopp/go-staticmaps v0.0.0-20220221183018-c226716bec53 // indirect
+	github.com/fogleman/gg v1.3.0 // indirect
 	github.com/fsnotify/fsnotify v1.5.4 // indirect
+	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 // indirect
+	github.com/golang/geo v0.0.0-20210211234256-740aa86cb551 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/magiconair/properties v1.8.6 // indirect
@@ -33,6 +38,9 @@ require (
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/subosito/gotenv v1.3.0 // indirect
+	github.com/tkrajina/gpxgo v1.1.2 // indirect
+	golang.org/x/image v0.0.0-20220302094943-723b81ca9867 // indirect
+	golang.org/x/net v0.0.0-20220520000938-2e3eb7b945c2 // indirect
 	golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a // indirect
 	gopkg.in/ini.v1 v1.66.4 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,8 @@ go 1.18
 
 require (
 	github.com/edgeware/mp4ff v0.29.0
+	github.com/flopp/go-staticmaps v0.0.0-20220221183018-c226716bec53
+	github.com/golang/geo v0.0.0-20210211234256-740aa86cb551
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/rs/zerolog v1.27.0
@@ -20,11 +22,9 @@ require (
 	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/flopp/go-coordsparser v0.0.0-20201115094714-8baaeb7062d5 // indirect
-	github.com/flopp/go-staticmaps v0.0.0-20220221183018-c226716bec53 // indirect
 	github.com/fogleman/gg v1.3.0 // indirect
 	github.com/fsnotify/fsnotify v1.5.4 // indirect
 	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 // indirect
-	github.com/golang/geo v0.0.0-20210211234256-740aa86cb551 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/magiconair/properties v1.8.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -60,6 +60,12 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/go-control-plane v0.9.7/go.mod h1:cwu0lG7PUMfa9snN8LXBig5ynNVH9qI8YYLbd1fK2po=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
+github.com/flopp/go-coordsparser v0.0.0-20201115094714-8baaeb7062d5 h1:o5yuyiGtJ4c9ECOq12K6EqsQNnsGF6I+WqBZynB2Hlw=
+github.com/flopp/go-coordsparser v0.0.0-20201115094714-8baaeb7062d5/go.mod h1:t5EAdR9sDhKR06Ix2ZS/8jt8INpzeV3P5uVyEkCDYJc=
+github.com/flopp/go-staticmaps v0.0.0-20220221183018-c226716bec53 h1:bpgLIxOpmht6HkBsajYmp+CvNAtdXnb+uGZQw3pIxtU=
+github.com/flopp/go-staticmaps v0.0.0-20220221183018-c226716bec53/go.mod h1:vGgI6wKa1TTiN9iumpzYZgNc/C7KxqsZbw9OH8O10iQ=
+github.com/fogleman/gg v1.3.0 h1:/7zJX8F6AaYQc57WQCyN9cAIz+4bCJGO9B+dyW29am8=
+github.com/fogleman/gg v1.3.0/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
 github.com/frankban/quicktest v1.14.3 h1:FJKSZTDHjyhriyC81FLQ0LY93eSai0ZyR/ZIkd3ZUKE=
 github.com/fsnotify/fsnotify v1.5.4 h1:jRbGcIw6P2Meqdwuo0H1p6JVLbL5DHKAKlYndzMwVZI=
 github.com/fsnotify/fsnotify v1.5.4/go.mod h1:OVB6XrOHzAwXMpEM7uPOzcehqUV2UqJxmVXmkdnm1bU=
@@ -69,6 +75,10 @@ github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2
 github.com/go-test/deep v1.0.8 h1:TDsG77qcSprGbC6vTN8OuXp5g+J+b5Pcguhf7Zt61VM=
 github.com/go-test/deep v1.0.8/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
+github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 h1:DACJavvAHhabrF08vX0COfcOBJRhZ8lUbR+ZWIs0Y5g=
+github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=
+github.com/golang/geo v0.0.0-20210211234256-740aa86cb551 h1:gtexQ/VGyN+VVFRXSFiguSNcXmS6rkKT+X7FdIrTtfo=
+github.com/golang/geo v0.0.0-20210211234256-740aa86cb551/go.mod h1:QZ0nwyI2jOfgRAoBvP+ab5aRr7c9x7lhGEJrKvBwjWI=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -132,6 +142,8 @@ github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
+github.com/joeshaw/gengen v0.0.0-20190604015154-c77d87825f5a/go.mod h1:v2qvRL8Xwk4OlARK6gPlf2JreZXzv0dYp/8+kUJ0y7Q=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
@@ -192,6 +204,8 @@ github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PK
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/subosito/gotenv v1.3.0 h1:mjC+YW8QpAdXibNi+vNWgzmgBH4+5l5dCXv8cNysBLI=
 github.com/subosito/gotenv v1.3.0/go.mod h1:YzJjq/33h7nrwdY+iHMhEOEEbW0ovIz0tB6t6PwAXzs=
+github.com/tkrajina/gpxgo v1.1.2 h1:il6rjS6IGm3yqa/yr7+fKBlF3ufWDEPZrYi/kxI1Jv0=
+github.com/tkrajina/gpxgo v1.1.2/go.mod h1:795sjVRFo5wWyN6oOZp0RYienGGBJjpAlgOz2nCngA0=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
@@ -222,6 +236,9 @@ golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6 h1:QE6XYQK6naiK1EPAe1g/ILLxN
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
+golang.org/x/image v0.0.0-20210628002857-a66eb6448b8d/go.mod h1:023OzeP/+EPmXeapQh35lcL3II3LrY8Ic+EFFKVhULM=
+golang.org/x/image v0.0.0-20220302094943-723b81ca9867 h1:TcHcE0vrmgzNH1v3ppjcMGbhG5+9fMuvOmUYwNEF4q4=
+golang.org/x/image v0.0.0-20220302094943-723b81ca9867/go.mod h1:023OzeP/+EPmXeapQh35lcL3II3LrY8Ic+EFFKVhULM=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190301231843-5614ed5bae6f/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
@@ -274,6 +291,9 @@ golang.org/x/net v0.0.0-20201031054903-ff519b6c9102/go.mod h1:sp8m0HH+o8qH0wwXwY
 golang.org/x/net v0.0.0-20201209123823-ac852fbbde11/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20201224014010-6772e930b67b/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
+golang.org/x/net v0.0.0-20210614182718-04defd469f4e/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20220520000938-2e3eb7b945c2 h1:NWy5+hlRbC7HK+PmcXVUmW1IMyFce7to56IUvhUFm7Y=
+golang.org/x/net v0.0.0-20220520000938-2e3eb7b945c2/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -325,6 +345,8 @@ golang.org/x/sys v0.0.0-20201201145000-ef89a241ccb3/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210104204734-6f8348627aad/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210225134936-a50acf3fe073/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423185535-09eb48e85fd7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -339,6 +361,7 @@ golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.4/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
@@ -353,6 +376,7 @@ golang.org/x/tools v0.0.0-20190312170243-e65039ee4138/go.mod h1:LCzVGOaR6xXOjkQ3
 golang.org/x/tools v0.0.0-20190425150028-36563e24a262/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20190506145303-2d16b83fe98c/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
+golang.org/x/tools v0.0.0-20190603231351-8aaa1484dc10/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190606124116-d0a3d012864b/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190621195816-6e04913cbbac/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190628153133-6cdbf07be9d0/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=

--- a/pkg/image/doc.go
+++ b/pkg/image/doc.go
@@ -1,0 +1,4 @@
+// Package image provides a simple wrapper to [go-staticmaps] for rendering
+// images of track data.
+// [go-staticmaps]: https://pkg.go.dev/github.com/flopp/go-staticmap
+package image

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -1,0 +1,111 @@
+package image
+
+import (
+	"fmt"
+	"image"
+	"image/color"
+	"image/png"
+	"io"
+	"os"
+
+	sm "github.com/flopp/go-staticmaps"
+	"github.com/golang/geo/s2"
+)
+
+const (
+	// defaultWeight is the default render weight.
+	defaultWeight = 2
+)
+
+var (
+	// Red represents the color Red.
+	Red = color.RGBA{R: 255, A: 0xff}
+
+	// Green represents the color Green.
+	Green = color.RGBA{G: 255, A: 0xff}
+
+	// Blue represents the color Blue.
+	Blue = color.RGBA{B: 255, A: 0xff}
+)
+
+// Option is a option to a Image.
+type Option func(*Image)
+
+// Render is function which writes a image img to w.
+type Render func(w io.Writer, img image.Image) error
+
+// Weight sets the for the paths rendered.
+// Default: 2.
+func Weight(weight float64) Option {
+	return func(i *Image) {
+		i.weight = weight
+	}
+}
+
+// Image represents an track session which can render an image.
+type Image struct {
+	*sm.Context // Embedded to provide flexibility.
+
+	weight float64
+	render Render
+}
+
+// New returns a new Image.
+func New(width, height int, options ...Option) *Image {
+	i := &Image{
+		render: png.Encode,
+		weight: defaultWeight,
+	}
+	i.Reset(width, height)
+
+	for _, f := range options {
+		f(i)
+	}
+
+	return i
+}
+
+// Reset resets the image context.
+func (i *Image) Reset(width, height int) {
+	i.Context = sm.NewContext()
+	i.SetSize(width, height)
+}
+
+// AddPath add a path represented by positions with color c to the image.
+func (i *Image) AddPath(positions []s2.LatLng, c color.Color) {
+	i.AddObject(sm.NewPath(positions, c, i.weight))
+}
+
+// Provider sets the provider title.
+func (i *Image) Provider(title string) {
+	prov := sm.NewTileProviderOpenStreetMaps()
+	prov.Attribution = fmt.Sprintf("%s | %s", prov.Attribution, title)
+	i.SetTileProvider(prov)
+}
+
+// Start adds the start line to image.
+func (i *Image) Start(lat1, lon1, lat2, lon2 float64) {
+	i.AddObject(sm.NewPath([]s2.LatLng{
+		s2.LatLngFromDegrees(lat1, lon1),
+		s2.LatLngFromDegrees(lat2, lon2),
+	}, Blue, i.weight))
+}
+
+// Render renders the image to file.
+func (i *Image) Render(file string) (err error) {
+	img, err := i.Context.Render()
+	if err != nil {
+		return err
+	}
+
+	f, err := os.Create(file)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if cerr := f.Close(); cerr != nil && err == nil {
+			err = cerr
+		}
+	}()
+	return i.render(f, img)
+}


### PR DESCRIPTION
Add to gopro render command which provides the ability to render a map image from the GPS data form a GoPro mp4 file.

It includes basic bad filtering based on the GPS DoP data which can be configured both on the command line and in the config file.