### PR TITLE
feat(gpmf): add hero 10 face support

### DIFF
--- a/pkg/gopro/gpmf/face.go
+++ b/pkg/gopro/gpmf/face.go
@@ -4,33 +4,102 @@ import (
 	"math"
 )
 
+// Face type sizes.
 const (
-	faceSizeHero6 = 20
-	faceSizeHero7 = 92
-	faceSizeHero8 = 28
+	faceSizeHero6  = 20
+	faceSizeHero7  = 92
+	faceSizeHero8  = 28
+	faceSizeHero10 = 14
+)
+
+// Face type definitions.
+const (
+	faceDefHero6  = "Lffff"
+	faceDefHero7  = "Lffffffffffffffffffffff"
+	faceDefHero8  = "Lffffff"
+	faceDefHero10 = "BBSSSSSBB"
 )
 
 var (
+	// faceTypeDefs is a map of all known face type definitions.
 	faceTypeDefs = map[string]byte{
-		"Lffff":                   faceSizeHero6,
-		"Lffffffffffffffffffffff": faceSizeHero7,
-		"Lffffff":                 faceSizeHero8,
+		faceDefHero6:  faceSizeHero6,
+		faceDefHero7:  faceSizeHero7,
+		faceDefHero8:  faceSizeHero8,
+		faceDefHero10: faceSizeHero10,
 	}
 )
 
-// Face represents face detection.
-type Face struct {
-	ID uint32
-	X  float32
-	Y  float32
-	W  float32
-	H  float32
-	// Only available on Hero 7+
-	Smile float32
-	// TODO(steve): complete the definition.
-	// https://github.com/gopro/gpmf-parser/issues/163
+// face is an interface that represents all face types.
+type face interface {
+	Face6 | Face7 | Face8 | Face10
 }
 
+// Face6 represents face detection for Hero 6.
+type Face6 struct {
+	// ID is the unique ID of the face.
+	ID uint32
+
+	// X is the starting coordinate on the horizontal axis of the face bounding box.
+	X float32
+
+	// Y is the starting coordinate on the vertical axis of the face bounding box.
+	Y float32
+
+	// Width is the width of the face bounding box.
+	Width float32
+
+	// Height is the hight of the face bounding box.
+	Height float32
+}
+
+// Face7 represents a detected face for Hero 7.
+type Face7 struct {
+	Face6
+
+	// Smile is the percentage confidence that the face is smiling.
+	Smile float32
+}
+
+// Face8 represents a detected face for Hero 7.
+type Face8 struct {
+	Face7
+
+	// Confidence is the percentage confidence that the face contains a face.
+	Confidence float32
+}
+
+// Face10 represents a detected face for Hero 10+.
+type Face10 struct {
+	// Version is the version of the face definition.
+	Version byte
+
+	// Confidence is the percentage confidence that the face contains a face.
+	Confidence byte
+
+	// ID is the unique ID of the face.
+	ID uint16
+
+	// X is the starting coordinate on the horizontal axis of the face bounding box.
+	X uint16
+
+	// Y is the starting coordinate on the vertical axis of the face bounding box.
+	Y uint16
+
+	// Width is the width of the face bounding box.
+	Width uint16
+
+	// Height is the hight of the face bounding box.
+	Height uint16
+
+	// Smile is the percentage confidence that the face is smiling.
+	Smile byte
+
+	// Blink is the percentage confidence that the face is blinking.
+	Blink byte
+}
+
+// parseFace parses a face detecting which format to be used.
 func parseFace(e *Element) error {
 	e.initMetadata()
 	if e.Header.Count == 0 {
@@ -38,31 +107,70 @@ func parseFace(e *Element) error {
 		return nil
 	}
 
-	if err := validateTypeDef(e, faceTypeDefs); err != nil {
+	def, err := validateTypeDef(e, faceTypeDefs)
+	if err != nil {
 		return err
 	}
 
+	switch def {
+	case faceDefHero6:
+		parseFaces(e, parseFace6)
+	case faceDefHero7:
+		parseFaces(e, parseFace7)
+	case faceDefHero8:
+		parseFaces(e, parseFace8)
+	case faceDefHero10:
+		parseFaces(e, parseFace10)
+	}
+
+	return nil
+}
+
+// parseFaces parses a set of faces using fn.
+func parseFaces[T face](e *Element, fn func(*T, []byte)) {
 	count := int(e.Header.Count)
 	size := int(e.Header.Size)
-	d := make([]Face, count)
+	d := make([]T, count)
 	for i, j := 0, 0; i < count; i, j = i+1, j+size {
-		f := Face{
-			ID: byteOrder.Uint32(e.raw[j:]),
-			X:  math.Float32frombits(byteOrder.Uint32(e.raw[j+4:])),
-			Y:  math.Float32frombits(byteOrder.Uint32(e.raw[j+8:])),
-			W:  math.Float32frombits(byteOrder.Uint32(e.raw[j+12:])),
-			H:  math.Float32frombits(byteOrder.Uint32(e.raw[j+16:])),
-		}
-		switch size {
-		case faceSizeHero7:
-			f.Smile = math.Float32frombits(byteOrder.Uint32(e.raw[j+92:]))
-		case faceSizeHero8:
-			f.Smile = math.Float32frombits(byteOrder.Uint32(e.raw[j+24:]))
-		}
+		var f T
+		fn(&f, e.raw[j:])
 		d[i] = f
 	}
 
 	e.Data = d
+}
 
-	return nil
+// parseFace6 parses a Hero 6 face.
+func parseFace6(f *Face6, raw []byte) {
+	f.ID = byteOrder.Uint32(raw)
+	f.X = math.Float32frombits(byteOrder.Uint32(raw[4:]))
+	f.Y = math.Float32frombits(byteOrder.Uint32(raw[8:]))
+	f.Width = math.Float32frombits(byteOrder.Uint32(raw[12:]))
+	f.Height = math.Float32frombits(byteOrder.Uint32(raw[16:]))
+}
+
+// parseFace7 parses a Hero 7 face.
+func parseFace7(f *Face7, raw []byte) {
+	parseFace6(&f.Face6, raw)
+	f.Smile = math.Float32frombits(byteOrder.Uint32(raw[92:]))
+}
+
+// parseFace8 parses a Hero 8+ face.
+func parseFace8(f *Face8, raw []byte) {
+	parseFace6(&f.Face6, raw)
+	f.Confidence = math.Float32frombits(byteOrder.Uint32(raw[20:]))
+	f.Smile = math.Float32frombits(byteOrder.Uint32(raw[24:]))
+}
+
+// parseFace10 parses a Hero 10+ face.
+func parseFace10(f *Face10, raw []byte) {
+	f.Version = raw[0]
+	f.Confidence = raw[1]
+	f.ID = byteOrder.Uint16(raw[3:])
+	f.X = byteOrder.Uint16(raw[5:])
+	f.Y = byteOrder.Uint16(raw[7:])
+	f.Width = byteOrder.Uint16(raw[9:])
+	f.Height = byteOrder.Uint16(raw[11:])
+	f.Smile = raw[13]
+	f.Blink = raw[14]
 }

--- a/pkg/gopro/gpmf/helpers.go
+++ b/pkg/gopro/gpmf/helpers.go
@@ -5,30 +5,31 @@ import (
 	"strings"
 )
 
-// validateTypeDef validates that e has a type definition which matches size and typeDef.
-func validateTypeDef(e *Element, typeDefs map[string]byte) error {
+// validateTypeDef validates that e has a type definition contained in typeDefs and
+// returns the one it matches.
+func validateTypeDef(e *Element, typeDefs map[string]byte) (string, error) {
 	f := e.friendlyName()
 
 	td, ok := e.Metadata[friendlyName(KeyTypeDef)]
 	if !ok {
-		return fmt.Errorf("%s: missing type def", f)
+		return "", fmt.Errorf("%s: missing type def", f)
 	}
 
 	t, ok := td.(string)
 	if !ok {
-		return fmt.Errorf("%s: unexpected type def type %T (expected string)", f, td)
+		return "", fmt.Errorf("%s: unexpected type def type %T (expected string)", f, td)
 	}
 
 	types := make([]string, 0, len(typeDefs))
 	for k, v := range typeDefs {
 		if t == k {
 			if e.Header.Size != v {
-				return fmt.Errorf("%s: unexpected data size %d (expected %d)", f, e.Header.Size, v)
+				return "", fmt.Errorf("%s: unexpected data size %d (expected %d)", f, e.Header.Size, v)
 			}
-			return nil
+			return t, nil
 		}
 		types = append(types, k)
 	}
 
-	return fmt.Errorf("%s: unexpected type def type %q (expected one of %s)", f, t, strings.Join(types, ","))
+	return "", fmt.Errorf("%s: unexpected type def type %q (expected one of %s)", f, t, strings.Join(types, ","))
 }


### PR DESCRIPTION
Add support for Hero 10 face detection.

This renames W -> Width and H -> Height as well a refactoring to have
separate types for the different versions Hero face detection.