### PR TITLE
fix(gopro): convert cfg and file return

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -59,6 +59,7 @@ linters:
     - gomoddirectives
     - ifshort
     - ireturn
+    - nosnakecase
 
 issues:
   exclude-use-default: false

--- a/cmd/tracktools/cmd/gopro_convert.go
+++ b/cmd/tracktools/cmd/gopro_convert.go
@@ -14,7 +14,7 @@ type goproConvertCmd struct {
 }
 
 func (c *goproConvertCmd) RunE(cmd *cobra.Command, args []string) error {
-	if err := loadConfig(cmd, c); err != nil {
+	if err := loadConfig(cmd, &c.cfg); err != nil {
 		return err
 	}
 

--- a/pkg/gopro/gpmf/element.go
+++ b/pkg/gopro/gpmf/element.go
@@ -183,7 +183,7 @@ func (e *Element) initMetadata() {
 // format returns the element data formatted according
 // to its Header information.
 func (e *Element) format(parent *Element) error {
-	if err := e.formatBasic(parent); err != nil {
+	if err := e.formatBasic(); err != nil {
 		return err
 	}
 
@@ -209,7 +209,7 @@ func (e *Element) format(parent *Element) error {
 
 // formatBasic stores the.Data version according
 // to its Header information.
-func (e *Element) formatBasic(parent *Element) error { // nolint: cyclop
+func (e *Element) formatBasic() error { // nolint: cyclop
 	switch e.Header.Type {
 	case Int8:
 		return e.formatInt8s()
@@ -218,7 +218,7 @@ func (e *Element) formatBasic(parent *Element) error { // nolint: cyclop
 	case String, FourCC, GUID:
 		return e.formatStrings()
 	case Int16:
-		return e.formatInt16s(parent)
+		return e.formatInt16s()
 	case Uint16:
 		return e.formatUint16s()
 	case Float32:
@@ -312,7 +312,7 @@ func (e *Element) formatStrings() error {
 	return nil
 }
 
-func (e *Element) formatInt16s(parent *Element) error {
+func (e *Element) formatInt16s() error {
 	size := 2
 	count := int(e.size) / size
 	if count == 1 {

--- a/pkg/gopro/processor.go
+++ b/pkg/gopro/processor.go
@@ -172,6 +172,8 @@ func (p *Processor) Process() ([]string, error) {
 		f, err := p.processSet(s)
 		if err != nil {
 			return files, err
+		} else if f == "" {
+			continue
 		}
 
 		files = append(files, f)

--- a/pkg/trackaddict/decoder.go
+++ b/pkg/trackaddict/decoder.go
@@ -37,7 +37,7 @@ func NewDecoder(r io.Reader, options ...Option) (*Decoder, error) {
 }
 
 // setup sets up column parsers.
-func (d *Decoder) columns(s *Session, cols []string) error { // nolint: gocyclo,cyclop
+func (d *Decoder) columns(cols []string) error { // nolint: gocyclo,cyclop
 	for _, col := range cols {
 		switch col {
 		case "Time":
@@ -227,7 +227,7 @@ func (d *Decoder) Decode() (*Session, error) {
 
 			if d.parsers == nil {
 				// First row must be the column names.
-				if err := d.columns(s, rec); err != nil {
+				if err := d.columns(rec); err != nil {
 					return nil, err
 				}
 			} else if err = d.process(n, lap, rec); err != nil {

--- a/pkg/trackaddict/gps.go
+++ b/pkg/trackaddict/gps.go
@@ -34,10 +34,10 @@ func (g *GPS) parseCoordinate(lat, long, head string) error {
 	if err := g.parseLatitude(lat); err != nil {
 		return err
 	}
-	if err := g.parseLongitude(lat); err != nil {
+	if err := g.parseLongitude(long); err != nil {
 		return err
 	}
-	return g.parseHeading(lat)
+	return g.parseHeading(head)
 }
 
 func parseGPSUpdate(r *Record, value string) (err error) {


### PR DESCRIPTION
Fix gopro convert not loading its configuration from file.

Skip files returned as blank, which indicates they where skipped.