### PR TITLE
ci: use setup-go cache

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,8 +14,8 @@ jobs:
   go:
     strategy:
       matrix:
-        go: [1.18]
-        golangcli: [v1.46.2]
+        go: [1.19]
+        golangcli: [1.50.1]
         os: [ubuntu-latest, macos-latest, windows-latest]
     name: lint
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -20,31 +20,14 @@ jobs:
     name: lint
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
       - name: Setup
         uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go }}
-
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Go Cache Paths
-        id: go-cache-paths
-        run: |
-          echo "::set-output name=go-build::$(go env GOCACHE)"
-          echo "::set-output name=go-mod::$(go env GOMODCACHE)"
-
-      - name: Go Build Cache
-        uses: actions/cache@v3
-        with:
-          path: ${{ steps.go-cache-paths.outputs.go-build }}
-          key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
-
-      - name: Go Mod Cache
-        uses: actions/cache@v3
-        with:
-          path: ${{ steps.go-cache-paths.outputs.go-mod }}
-          key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
+          cache: true
 
       - name: Validate go generate / mod
         if: runner.os != 'Windows'
@@ -60,8 +43,7 @@ jobs:
         with:
           version: ${{ matrix.golangci }}
           args: "--out-${NO_FUTURE}format colored-line-number"
-          skip-pkg-cache: true
-          skip-build-cache: true
+          skip-cache: true
 
       - name: Go Lint Windows
         if: runner.os == 'Windows'
@@ -71,8 +53,7 @@ jobs:
         with:
           version: ${{ matrix.golangci }}
           args: "--%outformat% colored-line-number"
-          skip-pkg-cache: true
-          skip-build-cache: true
+          skip-cache: true
 
       - name: Go Build
         run: go build ./...

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -60,7 +60,11 @@ linters:
     - ifshort
     - ireturn
     - nosnakecase
+    - deadcode
+    - varcheck
 
 issues:
+  exclude:
+    - .*Duplicate words \(.\.\) found.*
   exclude-use-default: false
   max-same-issues: 0

--- a/cmd/tracktools/cmd/convert.go
+++ b/cmd/tracktools/cmd/convert.go
@@ -31,7 +31,7 @@ type convertCmd struct {
 	StartDate date
 }
 
-func (c *convertCmd) RunE(cmd *cobra.Command, args []string) (err error) { // nolint: nonamedreturns
+func (c *convertCmd) RunE(cmd *cobra.Command, args []string) (err error) { //nolint: nonamedreturns
 	if err := loadConfig(cmd, c); err != nil {
 		return err
 	}
@@ -59,7 +59,7 @@ func (c *convertCmd) RunE(cmd *cobra.Command, args []string) (err error) { // no
 		if err != nil {
 			return fmt.Errorf("convert: input %w", err)
 		}
-		defer f.Close() // nolint: errcheck
+		defer f.Close() //nolint: errcheck
 		input = f
 	}
 
@@ -156,6 +156,6 @@ func addConvertCmd() {
 	rootCmd.AddCommand(cmd)
 }
 
-func init() { // nolint: gochecknoinits
+func init() { //nolint: gochecknoinits
 	addConvertCmd()
 }

--- a/cmd/tracktools/cmd/gopro.go
+++ b/cmd/tracktools/cmd/gopro.go
@@ -11,6 +11,6 @@ var goproCmd = &cobra.Command{
 	Long:  `Provides a set of commands for manipulating GoPro videos.`,
 }
 
-func init() { // nolint: gochecknoinits
+func init() { //nolint: gochecknoinits
 	rootCmd.AddCommand(goproCmd)
 }

--- a/cmd/tracktools/cmd/gopro_convert.go
+++ b/cmd/tracktools/cmd/gopro_convert.go
@@ -54,6 +54,6 @@ func addGoproConvert() {
 	goproCmd.AddCommand(cmd)
 }
 
-func init() { // nolint: gochecknoinits
+func init() { //nolint: gochecknoinits
 	addGoproConvert()
 }

--- a/cmd/tracktools/cmd/gopro_laptimes.go
+++ b/cmd/tracktools/cmd/gopro_laptimes.go
@@ -43,7 +43,7 @@ func (c *goproLapTimesCmd) process(dec *gpmf.Decoder, file string) error {
 		return fmt.Errorf("laptimes: open %w", err)
 	}
 
-	defer f.Close() // nolint: errcheck
+	defer f.Close() //nolint: errcheck
 
 	data, err := dec.Decode(f)
 	if err != nil {
@@ -98,6 +98,6 @@ func addGoproLapTimes() {
 	goproCmd.AddCommand(cmd)
 }
 
-func init() { // nolint: gochecknoinits
+func init() { //nolint: gochecknoinits
 	addGoproLapTimes()
 }

--- a/cmd/tracktools/cmd/gopro_render.go
+++ b/cmd/tracktools/cmd/gopro_render.go
@@ -35,7 +35,7 @@ func (c *goproRenderCmd) RunE(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("render: open %w", err)
 	}
 
-	defer f.Close() // nolint: errcheck
+	defer f.Close() //nolint: errcheck
 
 	data, err := dec.Decode(f)
 	if err != nil {
@@ -130,6 +130,6 @@ func addGoproRender() {
 	goproCmd.AddCommand(cmd)
 }
 
-func init() { // nolint: gochecknoinits
+func init() { //nolint: gochecknoinits
 	addGoproRender()
 }

--- a/cmd/tracktools/cmd/root.go
+++ b/cmd/tracktools/cmd/root.go
@@ -53,7 +53,7 @@ func Execute() {
 	}
 }
 
-func init() { // nolint: gochecknoinits
+func init() { //nolint: gochecknoinits
 	zerolog.SetGlobalLevel(zerolog.InfoLevel)
 	log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
 	newRoot()

--- a/cmd/tracktools/main.go
+++ b/cmd/tracktools/main.go
@@ -1,3 +1,5 @@
+// Command tracktools provide tools for converting Trackaddit to Harrys Laptimer
+// data files and processing GoPro files for use with these tools.
 package main
 
 import (

--- a/pkg/convert/trackaddict_test.go
+++ b/pkg/convert/trackaddict_test.go
@@ -14,7 +14,7 @@ import (
 func TestTrackAddict(t *testing.T) {
 	f, err := os.Open("../../test/Log-20220531-085930 Goodwood Motorcircuit - 2.57.527.csv")
 	require.NoError(t, err)
-	defer f.Close() // nolint: errcheck
+	defer f.Close() //nolint: errcheck
 
 	dec, err := trackaddict.NewDecoder(f)
 	require.NoError(t, err)

--- a/pkg/gopro/config.go
+++ b/pkg/gopro/config.go
@@ -133,7 +133,7 @@ func (c *Config) Load(file string) error {
 		return fmt.Errorf("config load: %w", err)
 	}
 
-	defer f.Close() // nolint: errcheck
+	defer f.Close() //nolint: errcheck
 
 	if c == nil {
 		c = &Config{}

--- a/pkg/gopro/gpmf/decoder_test.go
+++ b/pkg/gopro/gpmf/decoder_test.go
@@ -22,7 +22,7 @@ func TestDecoder(t *testing.T) {
 		t.Run(tc, func(t *testing.T) {
 			f, err := os.Open(filepath.Join("../../../test", tc+".mp4"))
 			require.NoError(t, err)
-			defer f.Close() // nolint: errcheck
+			defer f.Close() //nolint: errcheck
 
 			dec := &Decoder{}
 			_, err = dec.Decode(f)

--- a/pkg/gopro/gpmf/element.go
+++ b/pkg/gopro/gpmf/element.go
@@ -209,7 +209,7 @@ func (e *Element) format(parent *Element) error {
 
 // formatBasic stores the.Data version according
 // to its Header information.
-func (e *Element) formatBasic() error { // nolint: cyclop
+func (e *Element) formatBasic() error { //nolint: cyclop
 	switch e.Header.Type {
 	case Int8:
 		return e.formatInt8s()
@@ -284,11 +284,11 @@ func (e *Element) formatInt8s() error {
 
 func (e *Element) formatUint8s() error {
 	if e.Header.Count == 1 {
-		e.Data = uint8(e.raw[0]) // nolint: unconvert
+		e.Data = uint8(e.raw[0]) //nolint: unconvert
 		return nil
 	}
 
-	e.Data = []uint8(e.raw) // nolint: unconvert
+	e.Data = []uint8(e.raw) //nolint: unconvert
 
 	return nil
 }

--- a/pkg/gopro/gpmf/floats.go
+++ b/pkg/gopro/gpmf/floats.go
@@ -42,7 +42,7 @@ func floatType[T ~[]E, E any](e *Element, size int, f func([]float64) E) error {
 }
 
 // floatSlice converts data to a []float64.
-func floatSlice(data any) ([]float64, error) { // nolint: gocyclo,cyclop
+func floatSlice(data any) ([]float64, error) { //nolint: gocyclo,cyclop
 	switch v := data.(type) {
 	case []int8:
 		return toFloatSlice(v), nil

--- a/pkg/gopro/gpmf/geo/doc.go
+++ b/pkg/gopro/gpmf/geo/doc.go
@@ -3,8 +3,8 @@
 // It is a [Go] port of the gnomonic routines from [GeographicLib] and supporting helpers.
 //
 // The projection is derived in Section 8 of
-// - C. F. F. Karney, [Algorithms for geodesics], J. Geodesy 87, 43–55 (2013);
-//    DOI: [10.1007/s00190-012-0578-z]; [addenda].
+//   - C. F. F. Karney, [Algorithms for geodesics], J. Geodesy 87, 43–55 (2013);
+//     DOI: [10.1007/s00190-012-0578-z]; [addenda].
 //
 // The projection of P is defined as follows: compute the geodesic line from C to P;
 // compute the reduced length m12, geodesic scale M12, and ρ = m12/M12; finally x = ρ sin azi1;
@@ -21,13 +21,13 @@
 // closest to C the center of the projection and t be the distance CT. To lowest order, the maximum
 // deviation (as a true distance) of the corresponding gnomonic line segment (i.e., with the same end
 // points) from the geodesic is the following where K is the Gaussian curvature.
-//  (K(T) - K(C)) l² t / 32.
+//
+//	(K(T) - K(C)) l² t / 32.
 //
 // This result applies for any surface. For an ellipsoid of revolution, consider all geodesics whose
 // end points are within a distance r of C. For a given r, the deviation is maximum when the latitude
 // of C is 45°, when endpoints are a distance r away, and when their azimuths from the center are
 // ± 45° or ± 135°. To lowest order in r and the flattening f, the deviation is f (r/2a)³ r.
-//
 //
 // [Algorithms for geodesics]: https://doi.org/10.1007/s00190-012-0578-z
 // [10.1007/s00190-012-0578-z]: https://doi.org/10.1007/s00190-012-0578-z

--- a/pkg/gopro/gpmf/geo/gnomonic.go
+++ b/pkg/gopro/gpmf/geo/gnomonic.go
@@ -151,8 +151,9 @@ func (g *Gnomonic) Reverse(lat0, lon0, x, y float64) (lat, lon, azi, rk float64)
 // IntersectExt returns the intersection of lines A and B defined
 // by their end points as latitudes in the range [−90°, 90°] and
 // longitudes in degrees if they are extended.
-//   Line A: point 1 (lat1a, lon1a) -> point 2 (lat2a, lon2a)
-//   Line B: point 1 (lat1b, lon1b) -> point 2 (lat2b, lon2b)
+//
+//	Line A: point 1 (lat1a, lon1a) -> point 2 (lat2a, lon2a)
+//	Line B: point 1 (lat1b, lon1b) -> point 2 (lat2b, lon2b)
 //
 // It returns the latitude, longitide of intersection point and
 // the azimuths:
@@ -207,8 +208,9 @@ func (g *Gnomonic) IntersectExt(
 // Intersect returns the intersection latitude and longitude
 // of lines A and B defined by their end points as latitudes in
 // the range [−90°, 90°] and longitudes in degrees.
-//   Line A: point 1 (lat1a, lon1a) -> point 2 (lat2a, lon2a)
-//   Line B: point 1 (lat1b, lon1b) -> point 2 (lat2b, lon2b)
+//
+//	Line A: point 1 (lat1a, lon1a) -> point 2 (lat2a, lon2a)
+//	Line B: point 1 (lat1b, lon1b) -> point 2 (lat2b, lon2b)
 func (g *Gnomonic) Intersect(
 	lat1a, lon1a,
 	lat2a, lon2a,

--- a/pkg/gopro/gpmf/gyro.go
+++ b/pkg/gopro/gpmf/gyro.go
@@ -1,4 +1,4 @@
-package gpmf // nolint: dupl
+package gpmf //nolint: dupl
 
 import (
 	"time"

--- a/pkg/gopro/gpmf/header.go
+++ b/pkg/gopro/gpmf/header.go
@@ -39,7 +39,7 @@ func (h Header) Nested() bool {
 // Scalable returns true if its type is scalable,
 // false otherwise.
 func (h Header) Scalable() bool {
-	switch h.Type { // nolint: exhaustive
+	switch h.Type { //nolint: exhaustive
 	case Int8, Uint8,
 		Int16, Uint16,
 		Int32, Uint32,

--- a/pkg/gopro/gpmf/reader_test.go
+++ b/pkg/gopro/gpmf/reader_test.go
@@ -77,7 +77,7 @@ func TestReader(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			r := tc.reader(t)
 			if rc, ok := r.(io.Closer); ok {
-				defer rc.Close() // nolint: errcheck
+				defer rc.Close() //nolint: errcheck
 			}
 
 			data, err := reader.Read(r)

--- a/pkg/gopro/gpmf/wrgb.go
+++ b/pkg/gopro/gpmf/wrgb.go
@@ -1,4 +1,4 @@
-package gpmf // nolint: dupl
+package gpmf //nolint: dupl
 
 import (
 	"time"

--- a/pkg/gopro/osfs_test.go
+++ b/pkg/gopro/osfs_test.go
@@ -18,7 +18,7 @@ func TestOSFS(t *testing.T) {
 
 	name := tf.Name()
 
-	defer os.Remove(name) // nolint: errcheck
+	defer os.Remove(name) //nolint: errcheck
 
 	now := time.Now().Round(0)
 	err = o.Chtimes(name, now, now)

--- a/pkg/gopro/processor.go
+++ b/pkg/gopro/processor.go
@@ -211,7 +211,7 @@ func (p *Processor) processSet(s *FileSet) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to create temporary input file: %w", err)
 	}
-	defer baseFS.Remove(f.Name()) // nolint: errcheck
+	defer baseFS.Remove(f.Name()) //nolint: errcheck
 
 	if err := p.writeInput(f, s); err != nil {
 		return "", fmt.Errorf("write input file %q: %w", f.Name(), err)
@@ -245,7 +245,7 @@ func (p *Processor) processSet(s *FileSet) (string, error) {
 	// Set the input file name by index.
 	p.cfg.Args[p.cfg.inputIndex] = f.Name()
 
-	args := append(p.cfg.Args, output) // nolint: gocritic
+	args := append(p.cfg.Args, output) //nolint: gocritic
 	p.log.Print("handle:", p.cfg.Binary, args)
 	if err = p.handler(p.cfg.Binary, args...); err != nil {
 		return "", err

--- a/pkg/gopro/processor_test.go
+++ b/pkg/gopro/processor_test.go
@@ -325,7 +325,7 @@ func TestProcessorProcess(t *testing.T) {
 			var once sync.Once
 			closeWriter := func() {
 				// Close our copy of the files to allow pipe to trigger.
-				pw.Close() // nolint: errcheck
+				pw.Close() //nolint: errcheck
 			}
 
 			errs := make(chan error, 1)
@@ -416,7 +416,7 @@ func TestHelperProcess(t *testing.T) {
 	switch cmd {
 	case "ffmpeg":
 		fmt.Printf("%d:%s\n", os.Getpid(), args[len(args)-1])
-		os.Stdout.Close() // nolint: errcheck
+		os.Stdout.Close() //nolint: errcheck
 
 		// Wait for signal to exit.
 		select {

--- a/pkg/laptimer/decoder_test.go
+++ b/pkg/laptimer/decoder_test.go
@@ -45,7 +45,7 @@ func TestDecoder(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			f, err := os.Open(tc.file)
 			require.NoError(t, err)
-			defer f.Close() // nolint: errcheck
+			defer f.Close() //nolint: errcheck
 
 			buf, err := ioutil.ReadAll(f)
 			require.NoError(t, err)

--- a/pkg/laptimer/encoder.go
+++ b/pkg/laptimer/encoder.go
@@ -56,7 +56,7 @@ func (e *Encoder) Encode(v any) error {
 
 	errs := e.run(r)
 	if err := enc.Encode(v); err != nil {
-		w.Close() // nolint: errcheck
+		w.Close() //nolint: errcheck
 		return fmt.Errorf("encode: %w", err)
 	}
 

--- a/pkg/laptimer/types.go
+++ b/pkg/laptimer/types.go
@@ -692,9 +692,9 @@ type Duration time.Duration
 func (d Duration) String() string {
 	dur := time.Duration(d)
 	m := dur / time.Minute
-	mv := m * time.Minute // nolint: durationcheck
+	mv := m * time.Minute //nolint: durationcheck
 	s := (dur - mv) / time.Second
-	sv := s * time.Second // nolint: durationcheck
+	sv := s * time.Second //nolint: durationcheck
 	cs := (dur - mv - sv) / time.Millisecond / 10
 
 	return fmt.Sprintf("%02d:%02d.%02d",

--- a/pkg/laptimer/types_test.go
+++ b/pkg/laptimer/types_test.go
@@ -201,7 +201,7 @@ func TestIntermediatesXML(t *testing.T) {
 	}
 	data, err := xml.Marshal(v1)
 	require.NoError(t, err)
-	require.Equal(t, `<Intermediates>&#xA;&#x9;&#x9;&#x9;00:27.90,1142.1&#xA;&#x9;&#x9;&#x9;00:44.95,1862.0&#xA;&#x9;&#x9;</Intermediates>`, string(data)) // nolint: lll
+	require.Equal(t, `<Intermediates>&#xA;&#x9;&#x9;&#x9;00:27.90,1142.1&#xA;&#x9;&#x9;&#x9;00:44.95,1862.0&#xA;&#x9;&#x9;</Intermediates>`, string(data)) //nolint: lll
 
 	var v2 Intermediates
 	err = xml.Unmarshal(data, &v2)

--- a/pkg/trackaddict/decoder.go
+++ b/pkg/trackaddict/decoder.go
@@ -37,7 +37,7 @@ func NewDecoder(r io.Reader, options ...Option) (*Decoder, error) {
 }
 
 // setup sets up column parsers.
-func (d *Decoder) columns(cols []string) error { // nolint: gocyclo,cyclop
+func (d *Decoder) columns(cols []string) error { //nolint: gocyclo,cyclop
 	for _, col := range cols {
 		switch col {
 		case "Time":

--- a/pkg/trackaddict/decoder_test.go
+++ b/pkg/trackaddict/decoder_test.go
@@ -10,7 +10,7 @@ import (
 func TestDecoder(t *testing.T) {
 	f, err := os.Open("../../test/Log-20220531-085930 Goodwood Motorcircuit - 2.57.527.csv")
 	require.NoError(t, err)
-	defer f.Close() // nolint: errcheck
+	defer f.Close() //nolint: errcheck
 
 	d, err := NewDecoder(f)
 	require.NoError(t, err)

--- a/pkg/trackaddict/session.go
+++ b/pkg/trackaddict/session.go
@@ -75,7 +75,7 @@ func (s *Session) PredictOBD(predictor interp.FittablePredictor) error {
 		case 0:
 			predictors[i] = predictor
 		default:
-			// nolint: forcetypeassert
+			//nolint: forcetypeassert
 			predictors[i] = reflect.New(reflect.ValueOf(predictor).Elem().Type()).
 				Interface().(interp.FittablePredictor)
 		}


### PR DESCRIPTION
Use setup-go cache functionality instead of rolling our own to simplify the pipeline.

Use golangci-lint-action skip-cache to disable all caching in one line.