### PR TITLE
ci: update golangci-lint

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         go: [1.19]
-        golangcli: [1.50.1]
+        golangci: [v1.55.1]
         os: [ubuntu-latest, macos-latest, windows-latest]
     name: lint
     runs-on: ${{ matrix.os }}
@@ -24,10 +24,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
-          go-version: ${{ matrix.go }}
-          cache: true
+          go-version: '${{ matrix.go }}'
 
       - name: Validate go generate / mod
         if: runner.os != 'Windows'
@@ -37,23 +36,13 @@ jobs:
           go mod tidy
           git --no-pager diff && [[ 0 -eq $(git status --porcelain | wc -l) ]]
 
-      - name: Go Lint Standard
-        if: runner.os != 'Windows'
+      - name: Go Lint
         uses: golangci/golangci-lint-action@v3
         with:
           version: ${{ matrix.golangci }}
-          args: "--out-${NO_FUTURE}format colored-line-number"
-          skip-cache: true
-
-      - name: Go Lint Windows
-        if: runner.os == 'Windows'
-        uses: golangci/golangci-lint-action@v3
-        env:
-          outformat: out-format
-        with:
-          version: ${{ matrix.golangci }}
-          args: "--%outformat% colored-line-number"
-          skip-cache: true
+          args: --out-format=colored-line-number
+          skip-build-cache: true
+          skip-pkg-cache: true
 
       - name: Go Build
         run: go build ./...

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -62,6 +62,8 @@ linters:
     - nosnakecase
     - deadcode
     - varcheck
+    # Seems to be broken and just reports all the time.
+    - depguard
 
 issues:
   exclude:

--- a/cmd/tracktools/cmd/gopro_convert.go
+++ b/cmd/tracktools/cmd/gopro_convert.go
@@ -13,7 +13,7 @@ type goproConvertCmd struct {
 	cfg gopro.Config
 }
 
-func (c *goproConvertCmd) RunE(cmd *cobra.Command, args []string) error {
+func (c *goproConvertCmd) RunE(cmd *cobra.Command, _ []string) error {
 	if err := loadConfig(cmd, &c.cfg); err != nil {
 		return err
 	}

--- a/cmd/tracktools/cmd/root.go
+++ b/cmd/tracktools/cmd/root.go
@@ -60,7 +60,7 @@ func init() { //nolint: gochecknoinits
 }
 
 // PersistentPreRunE initialises our config.
-func (r *rootCommand) PersistentPreRunE(cmd *cobra.Command, args []string) error {
+func (r *rootCommand) PersistentPreRunE(_ *cobra.Command, _ []string) error {
 	v := viper.GetViper()
 
 	switch r.Verbose {
@@ -76,11 +76,7 @@ func (r *rootCommand) PersistentPreRunE(cmd *cobra.Command, args []string) error
 
 	v.AutomaticEnv()
 
-	if err := r.loadConfig(v); err != nil {
-		return err
-	}
-
-	return nil
+	return r.loadConfig(v)
 }
 
 // configSpec sets our config spec on v.

--- a/pkg/gopro/processor_other_test.go
+++ b/pkg/gopro/processor_other_test.go
@@ -13,5 +13,5 @@ func sig(pid int) error {
 }
 
 // cmdSetup for other OSes does nothing.
-func cmdSetup(cmd *exec.Cmd) {
+func cmdSetup(_ *exec.Cmd) {
 }

--- a/pkg/gopro/processor_test.go
+++ b/pkg/gopro/processor_test.go
@@ -78,7 +78,7 @@ func (t *testFS) CreateTemp(dir, pattern string) (tempFile, error) {
 	return f, nil
 }
 
-func (t *testFS) Chtimes(name string, atime time.Time, mtime time.Time) error {
+func (t *testFS) Chtimes(name string, _ time.Time, mtime time.Time) error {
 	t.mtx.Lock()
 	defer t.mtx.Unlock()
 

--- a/pkg/laptimer/types_test.go
+++ b/pkg/laptimer/types_test.go
@@ -149,7 +149,7 @@ func TestFloat0dpXML(t *testing.T) {
 	var v2 Float0dp
 	err = xml.Unmarshal(data, &v2)
 	require.NoError(t, err)
-	require.Equal(t, v1, v2)
+	require.Equal(t, v1, v2) //nolint: testifylint
 }
 
 func TestFloat1dpXML(t *testing.T) {
@@ -161,7 +161,7 @@ func TestFloat1dpXML(t *testing.T) {
 	var v2 Float1dp
 	err = xml.Unmarshal(data, &v2)
 	require.NoError(t, err)
-	require.Equal(t, v1, v2)
+	require.Equal(t, v1, v2) //nolint: testifylint
 }
 
 func TestFloat2dpXML(t *testing.T) {
@@ -173,7 +173,7 @@ func TestFloat2dpXML(t *testing.T) {
 	var v2 Float2dp
 	err = xml.Unmarshal(data, &v2)
 	require.NoError(t, err)
-	require.Equal(t, v1, v2)
+	require.Equal(t, v1, v2) //nolint: testifylint
 }
 
 func TestSyncPointXML(t *testing.T) {


### PR DESCRIPTION
Update golangci-lint to v1.55.1 and address new lint issues.

Fix go version specified for action.